### PR TITLE
cargo clippy

### DIFF
--- a/lyrebird/src/config.rs
+++ b/lyrebird/src/config.rs
@@ -41,7 +41,7 @@ impl Config
 	pub fn write(&self, paths: &ProjectDirs) -> Result<()>
 	{
 		let configPath = paths.config_dir();
-		create_dir_all(&configPath)?;
+		create_dir_all(configPath)?;
 		let configPath = configPath.join("config.json");
 		let configFile = File::create(configPath)?;
 		Ok(serde_json::to_writer(configFile, self)?)

--- a/lyrebird/src/config.rs
+++ b/lyrebird/src/config.rs
@@ -21,21 +21,19 @@ pub enum ConfigVersion
 
 impl Config
 {
-	pub fn read(paths: &ProjectDirs) -> Result<Config>
+	pub fn read(paths: &ProjectDirs) -> Result<Self>
 	{
 		let configPath = paths.config_dir().join("config.json");
 
 		if configPath.exists()
 		{
 			let configFile = File::open(configPath)?;
-			let config: Config = serde_json::from_reader(configFile)?;
+			let config = serde_json::from_reader(configFile)?;
 
-			Ok(config)
+			return Ok(config);
 		}
-		else
-		{
-			Ok(Config::default())
-		}
+		
+		Ok(Self::default())
 	}
 
 	pub fn write(&self, paths: &ProjectDirs) -> Result<()>
@@ -56,18 +54,10 @@ impl Default for Config
 		let userDirs = UserDirs::new().expect("Failed to get user directories");
 		// See if we can get the user's music directory
 		let musicDir = userDirs.audio_dir();
-		let musicDir = if let Some(dir) = musicDir
-		{
-			dir
-		}
-		else
-		{
-			// If we could not, default it to their homedir
-			userDirs.home_dir()
-		};
+		let musicDir = musicDir.map_or_else(|| userDirs.home_dir(), |dir| dir);
 
 		// Generate a configuration with this data
-		Config
+		Self
 		{
 			version: ConfigVersion::Version1,
 			libraryPath: musicDir.to_path_buf(),

--- a/lyrebird/src/config.rs
+++ b/lyrebird/src/config.rs
@@ -52,9 +52,8 @@ impl Default for Config
 	{
 		// Try to get the user directories
 		let userDirs = UserDirs::new().expect("Failed to get user directories");
-		// See if we can get the user's music directory
-		let musicDir = userDirs.audio_dir();
-		let musicDir = musicDir.map_or_else(|| userDirs.home_dir(), |dir| dir);
+		// See if we can get the user's music directory; if we can't, default to their homedir.
+		let musicDir = userDirs.audio_dir().map_or_else(|| userDirs.home_dir(), |dir| dir);
 
 		// Generate a configuration with this data
 		Self

--- a/lyrebird/src/library.rs
+++ b/lyrebird/src/library.rs
@@ -238,7 +238,7 @@ impl MusicLibrary
 			(
 				|files|
 				{
-					let files = BTreeSet::from_iter(files.iter());
+					let files = files.iter().collect::<BTreeSet<_>>();
 					files
 							.into_iter()
 							.map

--- a/lyrebird/src/library.rs
+++ b/lyrebird/src/library.rs
@@ -237,19 +237,18 @@ impl MusicLibrary
 			(
 				|files|
 				{
-					let files = files.iter().collect::<BTreeSet<_>>();
 					files
-							.into_iter()
-							.map
-							(
-								|file|
-								{
-									ListItem::new
-									(
-										file.file_name().unwrap_or_else(|| OsStr::new("")).to_string_lossy()
-									)
-								}
-							)
+						.iter()
+						.map
+						(
+							|file|
+							{
+								ListItem::new
+								(
+									file.file_name().unwrap_or_else(|| OsStr::new("")).to_string_lossy()
+								)
+							}
+						)
 				}
 			)
 	}

--- a/lyrebird/src/library.rs
+++ b/lyrebird/src/library.rs
@@ -1,4 +1,4 @@
-use std::{collections::{BTreeMap, BTreeSet}, ffi::OsStr, fs::{create_dir_all, File}, path::{Path, PathBuf}, sync::Arc};
+use std::{collections::{BTreeMap, BTreeSet}, ffi::OsStr, fs::{create_dir_all, File}, iter, path::{Path, PathBuf}, sync::Arc};
 
 use color_eyre::eyre::{self, OptionExt, Result};
 use libAudio::audioFile::AudioFile;
@@ -178,7 +178,7 @@ impl MusicLibrary
 	pub fn directories(&self) -> impl Iterator<Item = ListItem>
 	{
 		// Chain together the base library path, and the directories found within the library
-		std::iter::once(&self.basePath)
+		iter::once(&self.basePath)
 			.chain(self.dirs.iter())
 			.map
 			(
@@ -216,7 +216,7 @@ impl MusicLibrary
 	{
 		// Find the entry from the directories that describes the requested index
 		dirIndex
-			.and_then(|index| std::iter::once(&self.basePath).chain(self.dirs.iter()).nth(index))
+			.and_then(|index| iter::once(&self.basePath).chain(self.dirs.iter()).nth(index))
 			// Extract what files are in that directory
 			.and_then
 			(

--- a/lyrebird/src/library.rs
+++ b/lyrebird/src/library.rs
@@ -20,7 +20,7 @@ pub struct MusicLibrary
 	/// Paths to directories containing music relative to the root
 	dirs: BTreeSet<PathBuf>,
 	/// Map of directories to a list of files in that directory which are music
-	files: BTreeMap<PathBuf, Vec<PathBuf>>,
+	files: BTreeMap<PathBuf, BTreeSet<PathBuf>>,
 	#[serde(skip)]
 	discoveryCancellation: CancellationToken,
 
@@ -157,12 +157,12 @@ impl MusicLibrary
 					.ok_or_eyre("File does not have a valid path parent")?;
 				if !library.read().await.files.contains_key(filePath)
 				{
-					library.write().await.files.insert(filePath.to_path_buf(), Vec::new());
+					library.write().await.files.insert(filePath.to_path_buf(), BTreeSet::new());
 				}
 				// Now we definitely have a vec to use, look the path up and add the file
 				library.write().await.files.get_mut(filePath)
 					.ok_or_eyre("Failed to look file's path up in file map")?
-					.push(path);
+					.insert(path);
 			}
 			// If we're being asked to stop, stop
 			if library.read().await.discoveryCancellation.is_cancelled()

--- a/lyrebird/src/libraryTree.rs
+++ b/lyrebird/src/libraryTree.rs
@@ -151,7 +151,8 @@ impl Widget for &mut LibraryTree
 		);
 
 		// Build a list of files in the current directory being displayed
-		let filesList = libraryLock.filesFor(self.dirListState.selected()).map(List::new)
+		let filesList = libraryLock.filesFor(self.dirListState.selected())
+			.map(List::new)
 			.unwrap_or_default()
 			// Put it in a bordered block for presentation
 			.block

--- a/lyrebird/src/libraryTree.rs
+++ b/lyrebird/src/libraryTree.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::Path;
 use std::sync::Arc;
 
 use color_eyre::eyre::Result;
@@ -31,7 +31,7 @@ enum Side
 
 impl LibraryTree
 {
-	pub fn new(activeEntry: Style, cacheFile: PathBuf, libraryPath: &PathBuf) -> Result<Self>
+	pub fn new(activeEntry: Style, cacheFile: &Path, libraryPath: &Path) -> Result<Self>
 	{
 		Ok(LibraryTree
 		{
@@ -40,7 +40,7 @@ impl LibraryTree
 			dirListState: ListState::default().with_selected(Some(0)),
 			filesListState: ListState::default(),
 
-			library: MusicLibrary::new(&cacheFile, libraryPath)?,
+			library: MusicLibrary::new(cacheFile, libraryPath)?,
 		})
 	}
 
@@ -66,12 +66,12 @@ impl LibraryTree
 
 	fn moveLeft(&mut self)
 	{
-		self.activeSide = Side::DirectoryTree
+		self.activeSide = Side::DirectoryTree;
 	}
 
 	fn moveRight(&mut self)
 	{
-		self.activeSide = Side::Files
+		self.activeSide = Side::Files;
 	}
 
 	fn moveUp(&mut self)
@@ -136,7 +136,7 @@ impl Widget for &mut LibraryTree
 							match self.activeSide
 							{
 								Side::DirectoryTree => self.activeEntry,
-								_ => Style::default(),
+								Side::Files => Style::default(),
 							}
 						)
 						.border_type(BorderType::Rounded)
@@ -165,7 +165,7 @@ impl Widget for &mut LibraryTree
 						match self.activeSide
 						{
 							Side::Files => self.activeEntry,
-							_ => Style::default(),
+							Side::DirectoryTree => Style::default(),
 						}
 					)
 					// Make sure the contents are padded one space on the sides for presentation

--- a/lyrebird/src/libraryTree.rs
+++ b/lyrebird/src/libraryTree.rs
@@ -35,7 +35,7 @@ impl LibraryTree
 	{
 		Ok(LibraryTree
 		{
-			activeEntry: activeEntry,
+			activeEntry,
 			activeSide: Side::DirectoryTree,
 			dirListState: ListState::default().with_selected(Some(0)),
 			filesListState: ListState::default(),
@@ -151,8 +151,7 @@ impl Widget for &mut LibraryTree
 		);
 
 		// Build a list of files in the current directory being displayed
-		let filesList = libraryLock.filesFor(self.dirListState.selected())
-			.and_then(|files| Some(List::new(files)))
+		let filesList = libraryLock.filesFor(self.dirListState.selected()).map(List::new)
 			.unwrap_or_default()
 			// Put it in a bordered block for presentation
 			.block

--- a/lyrebird/src/libraryTree.rs
+++ b/lyrebird/src/libraryTree.rs
@@ -33,7 +33,7 @@ impl LibraryTree
 {
 	pub fn new(activeEntry: Style, cacheFile: &Path, libraryPath: &Path) -> Result<Self>
 	{
-		Ok(LibraryTree
+		Ok(Self
 		{
 			activeEntry,
 			activeSide: Side::DirectoryTree,
@@ -64,12 +64,12 @@ impl LibraryTree
 		}
 	}
 
-	fn moveLeft(&mut self)
+	const fn moveLeft(&mut self)
 	{
 		self.activeSide = Side::DirectoryTree;
 	}
 
-	fn moveRight(&mut self)
+	const fn moveRight(&mut self)
 	{
 		self.activeSide = Side::Files;
 	}

--- a/lyrebird/src/main.rs
+++ b/lyrebird/src/main.rs
@@ -34,13 +34,13 @@ fn run() -> Result<()>
 {
 	// Try to get the application paths available
 	let paths = ProjectDirs::from("com", "rachelmant", "Lyrebird").
-		ok_or(eyre::eyre!("Failed to get program working paths"))?;
+		ok_or_else(|| eyre::eyre!("Failed to get program working paths"))?;
 	// Now try to get a configuration object so we know where to find things and such
-	let mut config = Config::read(&paths)?;
+	let config = Config::read(&paths)?;
 
 	// Aquire the terminal to use and set up the main window w/ the configuration
 	let mut terminal = ratatui::init();
-	let mut mainWindow = MainWindow::new(&paths, &mut config)?;
+	let mut mainWindow = MainWindow::new(&paths, &config)?;
 	// Now run the main window of Lyrebird till the user exits the program
 	let result = mainWindow.run(&mut terminal);
 	// Give the terminal back and return the result of running the main window

--- a/lyrebird/src/main.rs
+++ b/lyrebird/src/main.rs
@@ -36,11 +36,11 @@ fn run() -> Result<()>
 	let paths = ProjectDirs::from("com", "rachelmant", "Lyrebird").
 		ok_or_else(|| eyre::eyre!("Failed to get program working paths"))?;
 	// Now try to get a configuration object so we know where to find things and such
-	let config = Config::read(&paths)?;
+	let mut config = Config::read(&paths)?;
 
 	// Aquire the terminal to use and set up the main window w/ the configuration
 	let mut terminal = ratatui::init();
-	let mut mainWindow = MainWindow::new(&paths, &config)?;
+	let mut mainWindow = MainWindow::new(&paths, &mut config)?;
 	// Now run the main window of Lyrebird till the user exits the program
 	let result = mainWindow.run(&mut terminal);
 	// Give the terminal back and return the result of running the main window

--- a/lyrebird/src/window.rs
+++ b/lyrebird/src/window.rs
@@ -59,7 +59,7 @@ impl MainWindow
 			header: Style::new().blue().on_black(),
 			headerEntry: Style::new().blue().on_black(),
 			headerNumber: Style::new().light_blue().on_black(),
-			activeEntry: activeEntry,
+			activeEntry,
 			footer: Style::new().blue().on_black(),
 
 			exit: false,
@@ -224,7 +224,7 @@ impl Widget for &mut MainWindow
 		Line::styled(errorState, self.footer).render(footerLayout[2], buf);
 
 		// Render the spacers for all the components of the footer
-		for spacerRect in footerSpacers.into_iter()
+		for spacerRect in footerSpacers.iter()
 		{
 			Line::styled("│", self.footer).render(*spacerRect, buf);
 		}

--- a/lyrebird/src/window.rs
+++ b/lyrebird/src/window.rs
@@ -41,7 +41,7 @@ enum Tab
 
 impl Tab
 {
-	fn value(self) -> usize
+	const fn value(self) -> usize
 	{
 		self as usize
 	}
@@ -50,11 +50,11 @@ impl Tab
 impl MainWindow
 {
 	/// Set up a new main window, building the style pallet needed
-	pub fn new(paths: &ProjectDirs, config: &mut Config) -> Result<Self>
+	pub fn new(paths: &ProjectDirs, config: &Config) -> Result<Self>
 	{
 		let activeEntry = Style::new().light_blue();
 
-		Ok(MainWindow
+		Ok(Self
 		{
 			header: Style::new().blue().on_black(),
 			headerEntry: Style::new().blue().on_black(),

--- a/lyrebird/src/window.rs
+++ b/lyrebird/src/window.rs
@@ -50,7 +50,7 @@ impl Tab
 impl MainWindow
 {
 	/// Set up a new main window, building the style pallet needed
-	pub fn new(paths: &ProjectDirs, config: &Config) -> Result<Self>
+	pub fn new(paths: &ProjectDirs, config: &mut Config) -> Result<Self>
 	{
 		let activeEntry = Style::new().light_blue();
 
@@ -100,7 +100,8 @@ impl MainWindow
 				if key.kind == KeyEventKind::Press
 				{
 					// Check to see if the event is for quitting
-					match key.code {
+					match key.code
+					{
 						KeyCode::Char('q' | 'Q') => 
 							{ return self.quit(); },
 						_ => {}

--- a/lyrebird/src/window.rs
+++ b/lyrebird/src/window.rs
@@ -100,9 +100,10 @@ impl MainWindow
 				if key.kind == KeyEventKind::Press
 				{
 					// Check to see if the event is for quitting
-					if let KeyCode::Char('q' | 'Q') = key.code 
-					{ 
-						return self.quit(); 
+					match key.code {
+						KeyCode::Char('q' | 'Q') => 
+							{ return self.quit(); },
+						_ => {}
 					}
 				}
 				// It's some other kind of event, so figure out which is the active

--- a/lyrebird/src/window.rs
+++ b/lyrebird/src/window.rs
@@ -41,9 +41,9 @@ enum Tab
 
 impl Tab
 {
-	fn value(&self) -> usize
+	fn value(self) -> usize
 	{
-		*self as usize
+		self as usize
 	}
 }
 
@@ -67,7 +67,7 @@ impl MainWindow
 
 			libraryTree: LibraryTree::new
 			(
-				activeEntry, paths.cache_dir().join("library.json"), &config.libraryPath
+				activeEntry, &paths.cache_dir().join("library.json"), &config.libraryPath
 			)?,
 
 			currentlyPlaying: None,
@@ -100,11 +100,9 @@ impl MainWindow
 				if key.kind == KeyEventKind::Press
 				{
 					// Check to see if the event is for quitting
-					match key.code
-					{
-						KeyCode::Char('q') | KeyCode::Char('Q') =>
-							{ return self.quit(); },
-						_ => {}
+					if let KeyCode::Char('q' | 'Q') = key.code 
+					{ 
+						return self.quit(); 
 					}
 				}
 				// It's some other kind of event, so figure out which is the active
@@ -154,7 +152,7 @@ impl Widget for &mut MainWindow
 
 		// Make the header tab titles
 		let headerTabs: Vec<_> = ["Tree", "Artists", "Albums", "Options", "Playlist"]
-			.map(|title| title.to_string())
+			.map(ToString::to_string)
 			.into_iter()
 			.enumerate()
 			.map(|(num, tabTitle)|
@@ -199,7 +197,7 @@ impl Widget for &mut MainWindow
 		// Figure out what strings are to be displayed in the footer
 		let currentlyPlaying = self.currentlyPlaying.as_ref().map_or_else
 		(
-			|| String::from("Nothing playing"), |playing| playing.clone()
+			|| String::from("Nothing playing"), Clone::clone
 		);
 		let songDuration = self.songDuration.map_or_else
 		(
@@ -211,7 +209,7 @@ impl Widget for &mut MainWindow
 		);
 		let errorState = self.errorState.as_ref().map_or_else
 		(
-			|| String::from("No errors"), |error| error.clone()
+			|| String::from("No errors"), Clone::clone
 		);
 
 		// Display the program footer - which song is currently playing, song runtime, and whether errors have occured


### PR DESCRIPTION
- Fixed a case where you were passing a reference to a reference.
- It's generally better to use `&Path` rather than `&PathBuf`; it's like `string_view` vs `string`.
- you can replace `.and_then(|...| Some(foo))` with `.map(foo)` because you can iterate over `Option`s.
- when working with a slice, `.into_iter()` and `.iter()` are equivalent, and the latter is considered a bit more concise.