### PR TITLE
Add rust-toolchain and carg-deny files

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,17 @@
+[advisories]
+ignore = [
+    # ratatui depends on paste that have been marked as unmaintained (https://rustsec.org/advisories/RUSTSEC-2024-0436)
+    # The next release of ratatui will remove dependency on it (see https://github.com/ratatui/ratatui/issues/1712)
+    "RUSTSEC-2024-0436"
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MPL-2.0",
+    "Unicode-3.0",
+    'Zlib'
+]
+exceptions = []

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.85.1"
+profile = "minimal"


### PR DESCRIPTION
This PR add two things:
- A [rust-toolchain.toml file](https://rust-lang.github.io/rustup/overrides.html) allowing to pin Rust to 1.85.1 when using rustup
- a [deny.toml file](https://embarkstudios.github.io/cargo-deny/checks/index.html) allowing to lint dependencies with [cargo-deny](https://github.com/EmbarkStudios/cargo-deny) from licenses to security advisories.